### PR TITLE
remove footgun from test code

### DIFF
--- a/test/Editor.tsx
+++ b/test/Editor.tsx
@@ -30,12 +30,14 @@ export function Editor({ handle, path }: EditorProps) {
       parent: containerRef.current,
     }))
 
-    handle.addListener("change", ({ doc, patchInfo }) => {
+    const handleChange = ({ doc, patchInfo }) => {
       semaphore.reconcile(handle, view)
-    })
+    }
+
+    handle.addListener("change", handleChange)
 
     return () => {
-      handle.removeAllListeners()
+      handle.removeListener("change", handleChange)
       view.destroy()
     }
   }, [])


### PR DESCRIPTION
The sample editor component in the tests works fine in isolation, but when used as sample starter code for a real application it can wreak havoc, since it removes all listeners on the handle on teardown.
This changes the behavior to only remove the listener used by this editor component.