### PR TITLE
Fix remote change handling

### DIFF
--- a/src/PatchSemaphore.ts
+++ b/src/PatchSemaphore.ts
@@ -1,4 +1,4 @@
-import { next as automerge } from "@automerge/automerge"
+import { next as automerge, equals } from "@automerge/automerge"
 import { DocHandle } from "@automerge/automerge-repo"
 import { EditorView } from "@codemirror/view"
 import codeMirrorToAm from "./codeMirrorToAm"
@@ -70,7 +70,7 @@ export class PatchSemaphore {
 
       // now get the diff between the updated state of the document and the heads
       // and apply that to the codemirror doc
-      const diff = automerge.diff(handle.docSync(), oldHeads, newHeads)
+      const diff = automerge.equals(oldHeads, newHeads) ? [] : automerge.diff(handle.docSync(), oldHeads, newHeads)
       amToCodemirror(view, selection, path, diff)
 
       view.dispatch({


### PR DESCRIPTION
Fixes a couple of issues related to handling changes from remote peers.

Generally the issues appear because `getHeads` can return patches even if those patches would result in a no-op. This messes up the selection in codemirror and sometimes causes runtime errors.

Notice the selection jump to the end of the string when typing "123":

![Kapture 2023-11-13 at 19 20 05](https://github.com/automerge/automerge-codemirror/assets/35851437/66eeaf82-0a56-46a4-90e3-8f0f1edff4e2)

