### PR TITLE
Bugfix: Editor not responding on empty input

### DIFF
--- a/src/codeMirrorToAm.ts
+++ b/src/codeMirrorToAm.ts
@@ -20,7 +20,7 @@ export default function (
   // Otherwise later on `automerge.diff` will return empty patches that result in a no-op but still mess up the selection.
   let hasChanges = false
   for (const tr of transactions) {
-    if (tr.changes.length) {
+    if (!tr.changes.empty) {
       tr.changes.iterChanges(() => {
         hasChanges = true
       })

--- a/test/Editor.cy.tsx
+++ b/test/Editor.cy.tsx
@@ -72,10 +72,7 @@ describe("<Editor />", () => {
       const { handle } = makeHandle("")
       mount(<Editor handle={handle} path={["text"]} />)
       cy.get("div.cm-content").type("{backspace}Hello")
-      cy.get("div.cm-content").should(
-        "have.html",
-        expectedHtml(["Hello"])
-      )
+      cy.get("div.cm-content").should("have.html", expectedHtml(["Hello"]))
       cy.wait(100).then(async () => {
         const doc = await handle.doc()
         assert.equal(doc.text, "Hello")

--- a/test/Editor.cy.tsx
+++ b/test/Editor.cy.tsx
@@ -67,6 +67,20 @@ describe("<Editor />", () => {
         })
       })
     })
+
+    it("handles inserting when the initial document is blank", () => {
+      const { handle } = makeHandle("")
+      mount(<Editor handle={handle} path={["text"]} />)
+      cy.get("div.cm-content").type("{backspace}Hello")
+      cy.get("div.cm-content").should(
+        "have.html",
+        expectedHtml(["Hello"])
+      )
+      cy.wait(100).then(async () => {
+        const doc = await handle.doc()
+        assert.equal(doc.text, "Hello")
+      })
+    })
   })
 
   describe("remote changes", () => {


### PR DESCRIPTION
The tr.changes.length property returns the length of the document before the change, meaning that if a change was applied to an empty document, it was ignored. As a result, if the document was empty, you could not write to it via the editor.