### PR TITLE
refactor: Make the plugin self-contained

### DIFF
--- a/src/PatchSemaphore.ts
+++ b/src/PatchSemaphore.ts
@@ -1,86 +1,69 @@
-import { next as automerge, equals } from "@automerge/automerge"
-import { DocHandle } from "@automerge/automerge-repo"
-import { EditorView } from "@codemirror/view"
-import codeMirrorToAm from "./codeMirrorToAm"
-import amToCodemirror from "./amToCodemirror"
-import {
-  Field,
-  isReconcileTx,
-  getPath,
-  reconcileAnnotationType,
-  updateHeads,
-  getLastHeads,
-} from "./plugin"
+import { next as automerge } from '@automerge/automerge';
 
-type Doc<T> = automerge.Doc<T>
-type Heads = automerge.Heads
+import amToCodemirror from './amToCodemirror';
+import codeMirrorToAm from './codeMirrorToAm';
+import { type IDocHandle } from './handle';
+import { type Field, isReconcileTx, getPath, reconcileAnnotationType, updateHeads, getLastHeads } from './plugin';
+import { type EditorView } from '@codemirror/view';
 
-type ChangeFn = (
-  atHeads: Heads,
-  change: (doc: Doc<unknown>) => void
-) => Heads | undefined
+type Doc<T> = automerge.Doc<T>;
+type Heads = automerge.Heads;
+
+type ChangeFn = (atHeads: Heads, change: (doc: Doc<unknown>) => void) => Heads | undefined;
 
 export class PatchSemaphore {
-  _field: Field
-  _inReconcile = false
-  _queue: Array<ChangeFn> = []
+  _field!: Field;
+  _inReconcile = false;
+  _queue: Array<ChangeFn> = [];
 
-  constructor(field: Field) {
-    this._field = field
-  }
-
-  reconcile = (handle: DocHandle<unknown>, view: EditorView) => {
-    if (this._inReconcile) {
-      return
-    } else {
-      this._inReconcile = true
-
-      const path = getPath(view.state, this._field)
-      const oldHeads = getLastHeads(view.state, this._field)
-      let selection = view.state.selection
-
-      const transactions = view.state
-        .field(this._field)
-        .unreconciledTransactions.filter(tx => !isReconcileTx(tx))
-
-      // First undo all the unreconciled transactions
-      const toInvert = transactions.slice().reverse()
-      for (const tx of toInvert) {
-        const inverted = tx.changes.invert(tx.startState.doc)
-        selection = selection.map(inverted)
-        view.dispatch({
-          changes: inverted,
-          annotations: reconcileAnnotationType.of(true),
-        })
-      }
-
-      // now apply the unreconciled transactions to the document
-      let newHeads = codeMirrorToAm(
-        this._field,
-        handle.changeAt.bind(handle),
-        transactions,
-        view.state
-      )
-
-      // NOTE: null and undefined each come from automerge and repo respectively
-      if (newHeads === null || newHeads === undefined) {
-        // TODO: @alexjg this is the call that's resetting the editor state on click
-        newHeads = automerge.getHeads(handle.docSync())
-      }
-
-      // now get the diff between the updated state of the document and the heads
-      // and apply that to the codemirror doc
-      const diff = automerge.equals(oldHeads, newHeads)
-        ? []
-        : automerge.diff(handle.docSync(), oldHeads, newHeads)
-      amToCodemirror(view, selection, path, diff)
-
-      view.dispatch({
-        effects: updateHeads(newHeads),
-        annotations: reconcileAnnotationType.of({}),
-      })
-
-      this._inReconcile = false
+  constructor(field?: Field) {
+    if (field !== undefined) {
+      this._field = field;
     }
   }
+
+  reconcile = (handle: IDocHandle, view: EditorView) => {
+    if (this._inReconcile) {
+      return;
+    }
+    this._inReconcile = true;
+
+    const path = getPath(view.state, this._field);
+    const oldHeads = getLastHeads(view.state, this._field);
+    let selection = view.state.selection;
+
+    const transactions = view.state.field(this._field).unreconciledTransactions.filter((tx) => !isReconcileTx(tx));
+
+    // First undo all the unreconciled transactions
+    const toInvert = transactions.slice().reverse();
+    for (const tx of toInvert) {
+      const inverted = tx.changes.invert(tx.startState.doc);
+      selection = selection.map(inverted);
+      view.dispatch({
+        changes: inverted,
+        annotations: reconcileAnnotationType.of(true),
+      });
+    }
+
+    // now apply the unreconciled transactions to the document
+    let newHeads = codeMirrorToAm(this._field, handle, transactions, view.state);
+
+    // NOTE: null and undefined each come from automerge and repo respectively
+    if (newHeads === null || newHeads === undefined) {
+      // TODO: @alexjg this is the call that's resetting the editor state on click
+      newHeads = automerge.getHeads(handle.docSync()!);
+    }
+
+    // now get the diff between the updated state of the document and the heads
+    // and apply that to the codemirror doc
+    const diff = automerge.equals(oldHeads, newHeads) ? [] : automerge.diff(handle.docSync()!, oldHeads, newHeads);
+    amToCodemirror(view, selection, path, diff);
+
+    view.dispatch({
+      effects: updateHeads(newHeads),
+      annotations: reconcileAnnotationType.of({}),
+    });
+
+    this._inReconcile = false;
+  };
 }

--- a/src/PatchSemaphore.ts
+++ b/src/PatchSemaphore.ts
@@ -22,14 +22,12 @@ type ChangeFn = (
 ) => Heads | undefined
 
 export class PatchSemaphore {
-  _field!: Field
+  _field: Field
   _inReconcile = false
   _queue: Array<ChangeFn> = []
 
-  constructor(field?: Field) {
-    if (field !== undefined) {
-      this._field = field
-    }
+  constructor(field: Field) {
+    this._field = field
   }
 
   reconcile = (handle: IDocHandle, view: EditorView) => {

--- a/src/amToCodemirror.ts
+++ b/src/amToCodemirror.ts
@@ -1,5 +1,10 @@
-import { ChangeSet, type ChangeSpec, type EditorSelection, type EditorState } from '@codemirror/state';
-import { type EditorView } from '@codemirror/view';
+import {
+  ChangeSet,
+  type ChangeSpec,
+  type EditorSelection,
+  type EditorState,
+} from "@codemirror/state"
+import { type EditorView } from "@codemirror/view"
 
 import {
   type DelPatch,
@@ -8,94 +13,113 @@ import {
   type Prop,
   type PutPatch,
   type SpliceTextPatch,
-} from '@automerge/automerge';
+} from "@automerge/automerge"
 
-import { reconcileAnnotationType } from './plugin';
+import { reconcileAnnotationType } from "./plugin"
 
-export default (view: EditorView, selection: EditorSelection, target: Prop[], patches: Patch[]) => {
+export default (
+  view: EditorView,
+  selection: EditorSelection,
+  target: Prop[],
+  patches: Patch[]
+) => {
   for (const patch of patches) {
-    const changeSpec = handlePatch(patch, target, view.state);
+    const changeSpec = handlePatch(patch, target, view.state)
     if (changeSpec != null) {
-      const changeSet = ChangeSet.of(changeSpec, view.state.doc.length, '\n');
-      selection = selection.map(changeSet, 1);
+      const changeSet = ChangeSet.of(changeSpec, view.state.doc.length, "\n")
+      selection = selection.map(changeSet, 1)
       view.dispatch({
         changes: changeSet,
         annotations: reconcileAnnotationType.of({}),
-      });
+      })
     }
   }
   view.dispatch({
     selection,
     annotations: reconcileAnnotationType.of({}),
-  });
-};
+  })
+}
 
-const handlePatch = (patch: Patch, target: Prop[], state: EditorState): ChangeSpec | null => {
-  if (patch.action === 'insert') {
-    return handleInsert(target, patch);
-  } else if (patch.action === 'splice') {
-    return handleSplice(target, patch);
-  } else if (patch.action === 'del') {
-    return handleDel(target, patch);
-  } else if (patch.action === 'put') {
-    return handlePut(target, patch, state);
+const handlePatch = (
+  patch: Patch,
+  target: Prop[],
+  state: EditorState
+): ChangeSpec | null => {
+  if (patch.action === "insert") {
+    return handleInsert(target, patch)
+  } else if (patch.action === "splice") {
+    return handleSplice(target, patch)
+  } else if (patch.action === "del") {
+    return handleDel(target, patch)
+  } else if (patch.action === "put") {
+    return handlePut(target, patch, state)
   } else {
-    return null;
+    return null
   }
-};
+}
 
-const handleInsert = (target: Prop[], patch: InsertPatch): Array<ChangeSpec> => {
-  const index = charPath(target, patch.path);
+const handleInsert = (
+  target: Prop[],
+  patch: InsertPatch
+): Array<ChangeSpec> => {
+  const index = charPath(target, patch.path)
   if (index == null) {
-    return [];
+    return []
   }
-  const text = patch.values.map((v) => (v ? v.toString() : '')).join('');
-  return [{ from: index, to: index, insert: text }];
-};
+  const text = patch.values.map(v => (v ? v.toString() : "")).join("")
+  return [{ from: index, to: index, insert: text }]
+}
 
-const handleSplice = (target: Prop[], patch: SpliceTextPatch): Array<ChangeSpec> => {
-  const index = charPath(target, patch.path);
+const handleSplice = (
+  target: Prop[],
+  patch: SpliceTextPatch
+): Array<ChangeSpec> => {
+  const index = charPath(target, patch.path)
   if (index == null) {
-    return [];
+    return []
   }
-  return [{ from: index, insert: patch.value }];
-};
+  return [{ from: index, insert: patch.value }]
+}
 
 const handleDel = (target: Prop[], patch: DelPatch): Array<ChangeSpec> => {
-  const index = charPath(target, patch.path);
+  const index = charPath(target, patch.path)
   if (index == null) {
-    return [];
+    return []
   }
-  const length = patch.length || 1;
-  return [{ from: index, to: index + length }];
-};
+  const length = patch.length || 1
+  return [{ from: index, to: index + length }]
+}
 
-const handlePut = (target: Prop[], patch: PutPatch, state: EditorState): Array<ChangeSpec> => {
-  const index = charPath(target, [...patch.path, 0]);
+const handlePut = (
+  target: Prop[],
+  patch: PutPatch,
+  state: EditorState
+): Array<ChangeSpec> => {
+  const index = charPath(target, [...patch.path, 0])
   if (index == null) {
-    return [];
+    return []
   }
-  const length = state.doc.length;
-  if (typeof patch.value !== 'string') {
-    return []; // TODO(dmaretskyi): How to handle non string values?
+  const length = state.doc.length
+  if (typeof patch.value !== "string") {
+    return [] // TODO(dmaretskyi): How to handle non string values?
   }
-  return [{ from: 0, to: length, insert: patch.value as any }];
-};
+  return [{ from: 0, to: length, insert: patch.value as any }]
+}
 
 // If the path of the patch is of the form [path, <index>] then we know this is
 // a path to a character within the sequence given by path
 const charPath = (textPath: Prop[], candidatePath: Prop[]): number | null => {
   if (candidatePath.length !== textPath.length + 1) {
-    return null;
+    return null
   }
   for (let i = 0; i < textPath.length; i++) {
     if (textPath[i] !== candidatePath[i]) {
-      return null;
+      return null
     }
   }
-  const index = candidatePath[candidatePath.length - 1];
-  if (typeof index === 'number') {
-    return index;
+  const index = candidatePath[candidatePath.length - 1]
+  if (typeof index === "number") {
+    return index
   }
-  return null;
-};
+  return null
+}

--- a/src/amToCodemirror.ts
+++ b/src/amToCodemirror.ts
@@ -1,114 +1,101 @@
-import {
-  DelPatch,
-  InsertPatch,
-  Patch,
-  Prop,
-  PutPatch,
-  SpliceTextPatch,
-} from "@automerge/automerge"
-import {
-  ChangeSet,
-  ChangeSpec,
-  EditorSelection,
-  EditorState,
-} from "@codemirror/state"
-import { EditorView } from "@codemirror/view"
-import { reconcileAnnotationType } from "./plugin"
+import { ChangeSet, type ChangeSpec, type EditorSelection, type EditorState } from '@codemirror/state';
+import { type EditorView } from '@codemirror/view';
 
-export default function (
-  view: EditorView,
-  selection: EditorSelection,
-  target: Prop[],
-  patches: Patch[]
-) {
+import {
+  type DelPatch,
+  type InsertPatch,
+  type Patch,
+  type Prop,
+  type PutPatch,
+  type SpliceTextPatch,
+} from '@automerge/automerge';
+
+import { reconcileAnnotationType } from './plugin';
+
+export default (view: EditorView, selection: EditorSelection, target: Prop[], patches: Patch[]) => {
   for (const patch of patches) {
-    const changeSpec = handlePatch(patch, target, view.state)
+    const changeSpec = handlePatch(patch, target, view.state);
     if (changeSpec != null) {
-      const changeSet = ChangeSet.of(changeSpec, view.state.doc.length, "\n")
-      selection = selection.map(changeSet, 1)
+      const changeSet = ChangeSet.of(changeSpec, view.state.doc.length, '\n');
+      selection = selection.map(changeSet, 1);
       view.dispatch({
         changes: changeSet,
         annotations: reconcileAnnotationType.of({}),
-      })
+      });
     }
   }
   view.dispatch({
     selection,
     annotations: reconcileAnnotationType.of({}),
-  })
-}
+  });
+};
 
-function handlePatch(
-  patch: Patch,
-  target: Prop[],
-  state: EditorState
-): ChangeSpec | null {
-  if (patch.action === "insert") {
-    return handleInsert(target, patch)
-  } else if (patch.action === "splice") {
-    return handleSplice(target, patch)
-  } else if (patch.action === "del") {
-    return handleDel(target, patch)
-  } else if (patch.action === "put") {
-    return handlePut(target, patch, state)
+const handlePatch = (patch: Patch, target: Prop[], state: EditorState): ChangeSpec | null => {
+  if (patch.action === 'insert') {
+    return handleInsert(target, patch);
+  } else if (patch.action === 'splice') {
+    return handleSplice(target, patch);
+  } else if (patch.action === 'del') {
+    return handleDel(target, patch);
+  } else if (patch.action === 'put') {
+    return handlePut(target, patch, state);
   } else {
-    return null
+    return null;
   }
-}
+};
 
-function handleInsert(target: Prop[], patch: InsertPatch): Array<ChangeSpec> {
-  const index = charPath(target, patch.path)
+const handleInsert = (target: Prop[], patch: InsertPatch): Array<ChangeSpec> => {
+  const index = charPath(target, patch.path);
   if (index == null) {
-    return []
+    return [];
   }
-  const text = patch.values.map(v => (v ? v.toString() : "")).join("")
-  return [{ from: index, to: index, insert: text }]
-}
+  const text = patch.values.map((v) => (v ? v.toString() : '')).join('');
+  return [{ from: index, to: index, insert: text }];
+};
 
-function handleSplice(
-  target: Prop[],
-  patch: SpliceTextPatch
-): Array<ChangeSpec> {
-  const index = charPath(target, patch.path)
+const handleSplice = (target: Prop[], patch: SpliceTextPatch): Array<ChangeSpec> => {
+  const index = charPath(target, patch.path);
   if (index == null) {
-    return []
+    return [];
   }
-  return [{ from: index, insert: patch.value }]
-}
+  return [{ from: index, insert: patch.value }];
+};
 
-function handleDel(target: Prop[], patch: DelPatch): Array<ChangeSpec> {
-  const index = charPath(target, patch.path)
+const handleDel = (target: Prop[], patch: DelPatch): Array<ChangeSpec> => {
+  const index = charPath(target, patch.path);
   if (index == null) {
-    return []
+    return [];
   }
-  const length = patch.length || 1
-  return [{ from: index, to: index + length }]
-}
+  const length = patch.length || 1;
+  return [{ from: index, to: index + length }];
+};
 
-function handlePut(
-  target: Prop[],
-  patch: PutPatch,
-  state: EditorState
-): Array<ChangeSpec> {
-  const index = charPath(target, [...patch.path, 0])
+const handlePut = (target: Prop[], patch: PutPatch, state: EditorState): Array<ChangeSpec> => {
+  const index = charPath(target, [...patch.path, 0]);
   if (index == null) {
-    return []
+    return [];
   }
-  const length = state.doc.length
-  if (typeof patch.value !== "string") {
-    return [] // TODO(dmaretskyi): How to handle non string values?
+  const length = state.doc.length;
+  if (typeof patch.value !== 'string') {
+    return []; // TODO(dmaretskyi): How to handle non string values?
   }
-  return [{ from: 0, to: length, insert: patch.value as any }]
-}
+  return [{ from: 0, to: length, insert: patch.value as any }];
+};
 
 // If the path of the patch is of the form [path, <index>] then we know this is
 // a path to a character within the sequence given by path
-function charPath(textPath: Prop[], candidatePath: Prop[]): number | null {
-  if (candidatePath.length !== textPath.length + 1) return null
-  for (let i = 0; i < textPath.length; i++) {
-    if (textPath[i] !== candidatePath[i]) return null
+const charPath = (textPath: Prop[], candidatePath: Prop[]): number | null => {
+  if (candidatePath.length !== textPath.length + 1) {
+    return null;
   }
-  const index = candidatePath[candidatePath.length - 1]
-  if (typeof index === "number") return index
-  return null
-}
+  for (let i = 0; i < textPath.length; i++) {
+    if (textPath[i] !== candidatePath[i]) {
+      return null;
+    }
+  }
+  const index = candidatePath[candidatePath.length - 1];
+  if (typeof index === 'number') {
+    return index;
+  }
+  return null;
+};

--- a/src/codeMirrorToAm.ts
+++ b/src/codeMirrorToAm.ts
@@ -1,37 +1,49 @@
-import { type EditorState, type Text, type Transaction } from '@codemirror/state';
+import {
+  type EditorState,
+  type Text,
+  type Transaction,
+} from "@codemirror/state"
 
-import { next as am, type Heads } from '@automerge/automerge';
+import { next as am, type Heads } from "@automerge/automerge"
 
-import { type IDocHandle } from './handle';
-import { type Field } from './plugin';
+import { type IDocHandle } from "./handle"
+import { type Field } from "./plugin"
 
 export default (
   field: Field,
   handle: IDocHandle,
   transactions: Transaction[],
-  state: EditorState,
+  state: EditorState
 ): Heads | undefined => {
-  const { lastHeads, path } = state.field(field);
+  const { lastHeads, path } = state.field(field)
 
   // We don't want to call `automerge.updateAt` if there are no changes.
   // Otherwise later on `automerge.diff` will return empty patches that result in a no-op but still mess up the selection.
-  let hasChanges = false;
+  let hasChanges = false
   for (const tr of transactions) {
     tr.changes.iterChanges(() => {
-      hasChanges = true;
-    });
+      hasChanges = true
+    })
   }
 
   if (!hasChanges) {
-    return undefined;
+    return undefined
   }
 
   const newHeads = handle.changeAt(lastHeads, (doc: am.Doc<unknown>) => {
     for (const tr of transactions) {
-      tr.changes.iterChanges((fromA: number, toA: number, _fromB: number, _toB: number, inserted: Text) => {
-        am.splice(doc, path, fromA, toA - fromA, inserted.toString());
-      });
+      tr.changes.iterChanges(
+        (
+          fromA: number,
+          toA: number,
+          _fromB: number,
+          _toB: number,
+          inserted: Text
+        ) => {
+          am.splice(doc, path, fromA, toA - fromA, inserted.toString())
+        }
+      )
     }
-  });
-  return newHeads ?? undefined;
-};
+  })
+  return newHeads ?? undefined
+}

--- a/src/codeMirrorToAm.ts
+++ b/src/codeMirrorToAm.ts
@@ -21,7 +21,7 @@ export default (
   // Otherwise later on `automerge.diff` will return empty patches that result in a no-op but still mess up the selection.
   let hasChanges = false
   for (const tr of transactions) {
-    if(!tr.changes.empty) {
+    if (!tr.changes.empty) {
       tr.changes.iterChanges(() => {
         hasChanges = true
       })

--- a/src/codeMirrorToAm.ts
+++ b/src/codeMirrorToAm.ts
@@ -21,9 +21,11 @@ export default (
   // Otherwise later on `automerge.diff` will return empty patches that result in a no-op but still mess up the selection.
   let hasChanges = false
   for (const tr of transactions) {
-    tr.changes.iterChanges(() => {
-      hasChanges = true
-    })
+    if(!tr.changes.empty) {
+      tr.changes.iterChanges(() => {
+        hasChanges = true
+      })
+    }
   }
 
   if (!hasChanges) {

--- a/src/codeMirrorToAm.ts
+++ b/src/codeMirrorToAm.ts
@@ -1,50 +1,37 @@
-import { next as am } from "@automerge/automerge"
-import { Heads } from "@automerge/automerge"
-import { EditorState, Text, Transaction } from "@codemirror/state"
-import { type Field } from "./plugin"
+import { type EditorState, type Text, type Transaction } from '@codemirror/state';
 
-type Update = (
-  atHeads: Heads,
-  change: (doc: am.Doc<unknown>) => void
-) => Heads | undefined
+import { next as am, type Heads } from '@automerge/automerge';
 
-export default function (
+import { type IDocHandle } from './handle';
+import { type Field } from './plugin';
+
+export default (
   field: Field,
-  update: Update,
+  handle: IDocHandle,
   transactions: Transaction[],
-  state: EditorState
-): Heads | undefined {
-  const { lastHeads, path } = state.field(field)
+  state: EditorState,
+): Heads | undefined => {
+  const { lastHeads, path } = state.field(field);
 
   // We don't want to call `automerge.updateAt` if there are no changes.
   // Otherwise later on `automerge.diff` will return empty patches that result in a no-op but still mess up the selection.
-  let hasChanges = false
+  let hasChanges = false;
   for (const tr of transactions) {
-    if (!tr.changes.empty) {
-      tr.changes.iterChanges(() => {
-        hasChanges = true
-      })
-    }
+    tr.changes.iterChanges(() => {
+      hasChanges = true;
+    });
   }
 
   if (!hasChanges) {
-    return undefined
+    return undefined;
   }
 
-  const newHeads = update(lastHeads, (doc: am.Doc<unknown>) => {
+  const newHeads = handle.changeAt(lastHeads, (doc: am.Doc<unknown>) => {
     for (const tr of transactions) {
-      tr.changes.iterChanges(
-        (
-          fromA: number,
-          toA: number,
-          _fromB: number,
-          _toB: number,
-          inserted: Text
-        ) => {
-          am.splice(doc, path, fromA, toA - fromA, inserted.toString())
-        }
-      )
+      tr.changes.iterChanges((fromA: number, toA: number, _fromB: number, _toB: number, inserted: Text) => {
+        am.splice(doc, path, fromA, toA - fromA, inserted.toString());
+      });
     }
-  })
-  return newHeads
-}
+  });
+  return newHeads ?? undefined;
+};

--- a/src/handle.ts
+++ b/src/handle.ts
@@ -1,0 +1,10 @@
+import type * as A from '@automerge/automerge';
+
+export type IDocHandle<T = any> = {
+  docSync(): A.Doc<T> | undefined;
+  change(callback: A.ChangeFn<T>, options?: A.ChangeOptions<T>): void;
+  changeAt(heads: A.Heads, callback: A.ChangeFn<T>, options?: A.ChangeOptions<T>): string[] | undefined;
+
+  addListener(event: 'change', listener: () => void): void;
+  removeListener(event: 'change', listener: () => void): void;
+};

--- a/src/handle.ts
+++ b/src/handle.ts
@@ -1,10 +1,14 @@
-import type * as A from '@automerge/automerge';
+import type * as A from "@automerge/automerge"
 
 export type IDocHandle<T = any> = {
-  docSync(): A.Doc<T> | undefined;
-  change(callback: A.ChangeFn<T>, options?: A.ChangeOptions<T>): void;
-  changeAt(heads: A.Heads, callback: A.ChangeFn<T>, options?: A.ChangeOptions<T>): string[] | undefined;
+  docSync(): A.Doc<T> | undefined
+  change(callback: A.ChangeFn<T>, options?: A.ChangeOptions<T>): void
+  changeAt(
+    heads: A.Heads,
+    callback: A.ChangeFn<T>,
+    options?: A.ChangeOptions<T>
+  ): string[] | undefined
 
-  addListener(event: 'change', listener: () => void): void;
-  removeListener(event: 'change', listener: () => void): void;
-};
+  addListener(event: "change", listener: () => void): void
+  removeListener(event: "change", listener: () => void): void
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { plugin } from "./plugin"
-export { PatchSemaphore } from "./PatchSemaphore"
+export { automergePlugin, type AutomergePlugin } from './plugin';
+export { type IDocHandle } from './handle';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { automergePlugin, type AutomergePlugin } from './plugin';
-export { type IDocHandle } from './handle';
+export { automergePlugin, type AutomergePlugin } from "./plugin"
+export { type IDocHandle } from "./handle"

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,44 +7,55 @@ import {
   StateField,
   type Transaction,
   type TransactionSpec,
-} from '@codemirror/state';
-import { ViewPlugin, type EditorView, type PluginValue, type ViewUpdate } from '@codemirror/view';
+} from "@codemirror/state"
+import {
+  ViewPlugin,
+  type EditorView,
+  type PluginValue,
+  type ViewUpdate,
+} from "@codemirror/view"
 
-import * as automerge from '@automerge/automerge';
-import { type Heads, type Prop } from '@automerge/automerge';
+import * as automerge from "@automerge/automerge"
+import { type Heads, type Prop } from "@automerge/automerge"
 
-import { PatchSemaphore } from './PatchSemaphore';
-import { type IDocHandle } from './handle';
+import { PatchSemaphore } from "./PatchSemaphore"
+import { type IDocHandle } from "./handle"
 
 export type Value = {
-  lastHeads: Heads;
-  path: Prop[];
-  unreconciledTransactions: Transaction[];
-};
+  lastHeads: Heads
+  path: Prop[]
+  unreconciledTransactions: Transaction[]
+}
 
 type UpdateHeads = {
-  newHeads: Heads;
-};
+  newHeads: Heads
+}
 
-export const effectType = StateEffect.define<UpdateHeads>({});
+export const effectType = StateEffect.define<UpdateHeads>({})
 
-export const updateHeads = (newHeads: Heads): StateEffect<UpdateHeads> => effectType.of({ newHeads });
+export const updateHeads = (newHeads: Heads): StateEffect<UpdateHeads> =>
+  effectType.of({ newHeads })
 
-export const getLastHeads = (state: EditorState, field: Field): Heads => state.field(field).lastHeads;
+export const getLastHeads = (state: EditorState, field: Field): Heads =>
+  state.field(field).lastHeads
 
-export const getPath = (state: EditorState, field: Field): Prop[] => state.field(field).path;
+export const getPath = (state: EditorState, field: Field): Prop[] =>
+  state.field(field).path
 
-export type Field = StateField<Value>;
+export type Field = StateField<Value>
 
 const semaphoreFacet = Facet.define<PatchSemaphore, PatchSemaphore>({
-  combine: (values) => values.at(-1)!, // Take last.
-});
+  combine: values => values.at(-1)!, // Take last.
+})
 
 export type AutomergePlugin = {
-  extension: Extension;
-};
+  extension: Extension
+}
 
-export const automergePlugin = (handle: IDocHandle, path: Prop[]): AutomergePlugin => {
+export const automergePlugin = (
+  handle: IDocHandle,
+  path: Prop[]
+): AutomergePlugin => {
   const stateField: StateField<Value> = StateField.define({
     create: () => ({
       lastHeads: automerge.getHeads(handle.docSync()!),
@@ -56,79 +67,83 @@ export const automergePlugin = (handle: IDocHandle, path: Prop[]): AutomergePlug
         lastHeads: value.lastHeads,
         unreconciledTransactions: value.unreconciledTransactions.slice(),
         path: path.slice(),
-      };
-      let clearUnreconciled = false;
+      }
+      let clearUnreconciled = false
       for (const effect of tr.effects) {
         if (effect.is(effectType)) {
-          result.lastHeads = effect.value.newHeads;
-          clearUnreconciled = true;
+          result.lastHeads = effect.value.newHeads
+          clearUnreconciled = true
         }
       }
       if (clearUnreconciled) {
-        result.unreconciledTransactions = [];
+        result.unreconciledTransactions = []
       } else {
         if (!isReconcileTx(tr)) {
-          result.unreconciledTransactions.push(tr);
+          result.unreconciledTransactions.push(tr)
         }
       }
-      return result;
+      return result
     },
-  });
-  const semaphore = new PatchSemaphore(stateField);
+  })
+  const semaphore = new PatchSemaphore(stateField)
 
   const viewPlugin = ViewPlugin.fromClass(
     class AutomergeCodemirrorViewPlugin implements PluginValue {
-      private _view: EditorView;
+      private _view: EditorView
 
       constructor(view: EditorView) {
-        this._view = view;
-        handle.addListener('change', this._handleChange);
+        this._view = view
+        handle.addListener("change", this._handleChange)
       }
 
       update(update: ViewUpdate) {
-        if (update.transactions.length > 0 && update.transactions.some((t) => !isReconcileTx(t))) {
+        if (
+          update.transactions.length > 0 &&
+          update.transactions.some(t => !isReconcileTx(t))
+        ) {
           queueMicrotask(() => {
             reconcile(handle, this._view)
-          });
+          })
         }
       }
 
       destroy() {
-        handle.addListener('change', this._handleChange);
+        handle.addListener("change", this._handleChange)
       }
 
       private _handleChange = () => {
         reconcile(handle, this._view)
-      };
-    },
-  );
+      }
+    }
+  )
 
   return {
     extension: [stateField, semaphoreFacet.of(semaphore), viewPlugin],
-  };
-};
+  }
+}
 
 const reconcile = (handle: IDocHandle, view: EditorView) => {
   const semaphore = view.state.facet<PatchSemaphore>(semaphoreFacet)
-  semaphore.reconcile(handle, view);
+  semaphore.reconcile(handle, view)
 }
 
-export const reconcileAnnotationType = Annotation.define<unknown>();
+export const reconcileAnnotationType = Annotation.define<unknown>()
 
-export const isReconcileTx = (tr: Transaction): boolean => !!tr.annotation(reconcileAnnotationType);
+export const isReconcileTx = (tr: Transaction): boolean =>
+  !!tr.annotation(reconcileAnnotationType)
 
 export const makeReconcile = (tr: TransactionSpec) => {
   if (tr.annotations != null) {
     if (tr.annotations instanceof Array) {
-      tr.annotations = [...tr.annotations, reconcileAnnotationType.of({})];
+      tr.annotations = [...tr.annotations, reconcileAnnotationType.of({})]
     } else {
-      tr.annotations = [tr.annotations, reconcileAnnotationType.of({})];
+      tr.annotations = [tr.annotations, reconcileAnnotationType.of({})]
     }
   } else {
-    tr.annotations = [reconcileAnnotationType.of({})];
+    tr.annotations = [reconcileAnnotationType.of({})]
   }
   // return {
   // ...tr,
   // annotations: reconcileAnnotationType.of({})
   // }
-};
+}


### PR DESCRIPTION
- Plugin is now now self-contained where only extensions: `[automergePlugin(handle, path)]` needs to be passed to configure the editor.
- Replaced the dependency on automerge-repo via an interface describing doc-handle so it can be used with `Doc` from `@automerge/automerge` package as well. 
