### PR TITLE
BugFix: Handling multiple changes in a singular transaction

### DIFF
--- a/src/codeMirrorToAm.ts
+++ b/src/codeMirrorToAm.ts
@@ -37,11 +37,13 @@ export default function (
         (
           fromA: number,
           toA: number,
-          _fromB: number,
+          fromB: number,
           _toB: number,
           inserted: Text
         ) => {
-          am.splice(doc, path, fromA, toA - fromA, inserted.toString())
+          // We are cloning the path as `am.splice` calls `.unshift` on it, modifying it in place,
+          // causing the path to be broken on subsequent changes
+          am.splice(doc, path.slice(), fromB, toA - fromA, inserted.toString())
         }
       )
     }

--- a/test/Editor.cy.tsx
+++ b/test/Editor.cy.tsx
@@ -78,6 +78,38 @@ describe("<Editor />", () => {
         assert.equal(doc.text, "Hello")
       })
     })
+
+    it("handles moving lines", () => {
+      const { handle } = makeHandle("Hello\nWorld")
+      mount(<Editor handle={handle} path={["text"]} />)
+      cy.get("div.cm-content").type("{ctrl+end}{alt+upArrow}")
+      cy.get("div.cm-content").should(
+        "have.html",
+        expectedHtml(["World", "Hello"], 1)
+      )
+      cy.wait(100).then(async () => {
+        const doc = await handle.doc()
+        assert.equal(doc.text, "World\nHello")
+      })
+    })
+
+    it("handles multiple cursors", () => {
+      const { handle } = makeHandle("Hello\nWorld\nThere!")
+      mount(<Editor handle={handle} path={["text"]} />)
+      cy.get("div.cm-content>.cm-line").eq(0).click()
+      cy.get("div.cm-content>.cm-line").eq(1).click({ ctrlKey: true })
+      cy.get("div.cm-content>.cm-line").eq(2).click({ ctrlKey: true })
+      cy.get("div.cm-content").type(" Lines{home}{shift+rightArrow}{del}")
+      cy.get("div.cm-content>.cm-line").eq(0).click()
+      cy.get("div.cm-content").should(
+        "have.html",
+        expectedHtml(["ello Lines", "orld Lines", "here! Lines"], 0)
+      )
+      cy.wait(100).then(async () => {
+        const doc = await handle.doc()
+        assert.equal(doc.text, "ello Lines\norld Lines\nhere! Lines")
+      })
+    })
   })
 
   describe("remote changes", () => {


### PR DESCRIPTION
When utilizing codemirror shortcuts such as alt+upArrow to move entire lines or editing via multiple cursors at once, a singular codemirror transaction may contain multiple changes in its change set, causing multiple `am.splice` calls.

This causes 2 issues:
1. `am.splice` modifies the provided path variable, causing it to be corrupted on subsequent iterations
2. The indices of the text document may have been altered by prior changes. Therefore, any subsequent modifications should utilize `fromB` instead of `fromA`, as it, unlike `fromA`, accounts for these index changes. Otherwise a `RangeError` may be thrown.