### PR TITLE
Add the block marker when a block insert comes in

### DIFF
--- a/src/amToCodemirror.ts
+++ b/src/amToCodemirror.ts
@@ -57,7 +57,9 @@ function handleInsert(target: Prop[], patch: InsertPatch): Array<ChangeSpec> {
   if (index == null) {
     return []
   }
-  const text = patch.values.map(v => (v ? v.toString() : "")).join("")
+  const text = patch.values
+    .map(v => (typeof v == "string" ? v : "\ufffc"))
+    .join("")
   return [{ from: index, to: index, insert: text }]
 }
 


### PR DESCRIPTION
if you do:

```js
splitBlock(
  doc,
  ["text"],
  2,
  {type: "paragraph", parents: []}
)
```

the patches go something like:

```
insert	["text", 2]      	[{}]
put 	["text", 2, "type"]   	""
put  	["text", 2, "parents"] 	[]
splice	["text", 2, "type", 0] 	"paragraph"
```

If your code expects that incoming Text inserts are going to be strings, you'll end up setting `text[2]` to the string `[object Object]`. (and then later trying to set `"[".type[0]` to `"paragraph"` which upsets the computer)

this patch makes it that an object insert to the target string is converted to `\ufffc`, which is what it would look like if you loaded the Text fresh rather than applying patches.

it's naïve, and assumes anything that isn't a string is a new block marker, but i don't have any better ideas right now